### PR TITLE
Update error checking and handling in SCL3300 library

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Arduino Library for Murata SCL3300 Inclinometer
 
-  Version 2.1.4 - August 4, 2020
+  Version 3.0.0 - August 10, 2020
 
   By David Armstrong
   https://github.com/DavidArmstrong/Arduino-SCL3300
@@ -20,6 +20,7 @@ Notes:
   1) The SCL3300 inclinometer will require a bidrectional level shifter to interface the SPI pins to 5 volt devices, such as the Arduino Uno.
   2) A pull-up resistor may be required on the Chip/Slave Select line of the SCL3300.  A typical resistor value of 4.7k ohms should connect this pin to +3.3 volts.
   3) Be sure to connect the SCL3300 DVIO pin to +3.3 volts as well.  This pin powers the digital pins.
+  4) There is a small, but significant, library change starting with Version 3.0.0.  This requires a one-line addition to any older sketches when using this updated SCL3300 library.  All the example sketches have been updated to include the addtional code.  (The backwards incompatibility is due to the improved error detection and handling design.)
 
 For an Arduino Uno, the default SPI pins are as follows:
 SCK - Digital Pin 13
@@ -39,7 +40,7 @@ begin(csPinNum) -- This variation allows you to choose a different pin as the SP
 
 isConnected()   -- Returns 'true' if the sensor is still responding as expected, and able to provide valid data.
 
-available()     -- Reads the raw SCL3300 sensor data as a group so that all the data is consistent.  Call this first before using the functions below.
+available()     -- Reads the raw SCL3300 sensor data as a group so that all the data is consistent.  Call this first before using the functions below.  Starting with Version 3.0.0, this call should be the conditional in an 'if' statement, and an 'else' clause included to call reset() when available() returns false.  (See the example sketches in the library.)
 
 getTiltLevelOffsetAngleX() -- Returns a double float of the tilt offset from level value in degrees for the X direction.
 

--- a/examples/Example1_BasicTiltLevelOffset/Example1_BasicTiltLevelOffset.ino
+++ b/examples/Example1_BasicTiltLevelOffset/Example1_BasicTiltLevelOffset.ino
@@ -1,5 +1,5 @@
 /* Read Tilt angles from Murata SCL3300 Inclinometer
- * Version 2.1.0 - February 29, 2020
+ * Version 3.0.0 - August 8, 2020
  * Example1_BasicTiltLevelOffset
 */
 
@@ -36,5 +36,5 @@ void loop() {
     Serial.print("Z Tilt: ");
     Serial.println(inclinometer.getTiltLevelOffsetAngleZ());
     delay(100); //Allow a little time to see the output
-  }
+  } else inclinometer.reset();
 }

--- a/examples/Example2_BasicTiltReading/Example2_BasicTiltReading.ino
+++ b/examples/Example2_BasicTiltReading/Example2_BasicTiltReading.ino
@@ -1,5 +1,5 @@
 /* Read Tilt angles from Murata SCL3300 Inclinometer
- * Version 2.0.0 - February 22, 2020
+ * Version 3.0.0 - August 8, 2020
  * Example2_BasicTiltReading
 */
 
@@ -36,5 +36,5 @@ void loop() {
     Serial.print("Z Tilt: ");
     Serial.println(inclinometer.getCalculatedAngleZ());
     delay(250); //Allow a little time to see the output
-  }
+  } else inclinometer.reset();
 }

--- a/examples/Example3_BasicAccelerometerReading/Example3_BasicAccelerometerReading.ino
+++ b/examples/Example3_BasicAccelerometerReading/Example3_BasicAccelerometerReading.ino
@@ -1,5 +1,5 @@
 /* Read Accelerometer data from Murata SCL3300 Inclinometer
- * Version 2.0.0 - February 22, 2020
+ * Version 3.0.0 - August 8, 2020
  * Example3_BasicAccelerometerReading
 */
 
@@ -36,5 +36,5 @@ void loop() {
     Serial.print("Z Accelerometer: ");
     Serial.println(inclinometer.getCalculatedAccelerometerZ());
     delay(250); //Allow a little time to see the output
-  }
+  } else inclinometer.reset();
 }

--- a/examples/Example4_BasicTemperatureReading/Example4_BasicTemperatureReading.ino
+++ b/examples/Example4_BasicTemperatureReading/Example4_BasicTemperatureReading.ino
@@ -1,5 +1,5 @@
 /* Read Temperature Sensor from Murata SCL3300 Inclinometer
- * Version 2.0.0 - February 22, 2020
+ * Version 3.0.0 - August 8, 2020
  * Example4_BasicTemperatureReading
 */
 
@@ -33,5 +33,5 @@ void loop() {
     Serial.print("Farenheit Temperature: ");
     Serial.println(inclinometer.getCalculatedTemperatureFarenheit());
     delay(250); //Allow a little time to see the output
-  }
+  } else inclinometer.reset();
 }

--- a/examples/Example5_RawDataReading/Example5_RawDataReading.ino
+++ b/examples/Example5_RawDataReading/Example5_RawDataReading.ino
@@ -1,5 +1,5 @@
 /* Read Raw sensor data from Murata SCL3300 Inclinometer
- * Version 2.1.1 - March 3, 2020
+ * Version 3.0.0 - August 8, 2020
  * Example5_RawDataReading
 */
 
@@ -27,6 +27,7 @@ void setup() {
 
 void loop() {
   if (inclinometer.isConnected()) Serial.println("Inclinometer is still alive...");
+  else Serial.println("Inclinometer error detected...");
   
   if (inclinometer.available()) { //Get next block of data from sensor
     Serial.print("Raw X Tilt: ");
@@ -59,5 +60,5 @@ void loop() {
     Serial.print("SL3300 Status Summary Register: ");
     Serial.println(inclinometer.sclData.StatusSum, HEX);
     delay(1000);
-  }
+  } else inclinometer.reset();
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SCL3300
-version=2.1.4
+version=3.0.0
 author=David Armstrong <mamoru.tbreesama@gmail.com>
 maintainer=David Armstrong <mamoru.tbreesama@gmail.com>
 sentence=A library for SPI communication with the Murata SCL3300 Inclinometer sensor.


### PR DESCRIPTION
This change forces the need to call reset() if the call to available() returns a false value.