### PR TITLE
Allow using different SPI instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ begin(csPinNum)<br>
 This variation allows you to choose a different pin as the SPI Chip Select Pin.  Replace 'csPinNum' with your pin number.
 
 begin(altSpiPort, csPinNum)<br>
-This allows using an alternate SPI port definition for communication to the SCL3300. Please see Example6_AlternateSPI.ino
+This allows using an alternate SPI port definition for communication to the SCL3300. Please see Example9_AlternateSPI.ino
 
 isConnected()<br>
 Returns 'true' if the sensor is still responding as expected, and able to provide valid data. It does not collect a data set from the sensor.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Arduino Library for Murata SCL3300 Inclinometer
 
-  Version 3.2.0 - September 3, 2021
+  Version 3.3.0 - September 13, 2021
 
   By David Armstrong
   https://github.com/DavidArmstrong/Arduino-SCL3300
@@ -38,49 +38,74 @@ For a SAMD-type Arduino, such as the Sparkfun Redboard Turbo or Arduino Zero, th
 
 Basic SCL3300 Library Functions:
 
-begin()         -- This initializes the library and the SPI chip, and by default assigns the SPI Chip Select Pin to Digital Pin 10.
+begin()<br>
+This initializes the library and the SPI chip, and by default assigns the SPI Chip Select Pin to Digital Pin 10.
 
-begin(csPinNum) -- This variation allows you to choose a different pin as the SPI Chip Select Pin.  Replace 'csPinNum' with your pin number.
+begin(csPinNum)<br>
+This variation allows you to choose a different pin as the SPI Chip Select Pin.  Replace 'csPinNum' with your pin number.
 
-isConnected()   -- Returns 'true' if the sensor is still responding as expected, and able to provide valid data.
+begin(altSpiPort, csPinNum)<br>
+This allows using an alternate SPI port definition for communication to the SCL3300. Please see Example6_AlternateSPI.ino
 
-available()     -- Reads the raw SCL3300 sensor data as a group so that all the data is consistent.  Call this first before using the functions below.  Starting with Version 3.0.0, this call should be the conditional in an 'if' statement, and an 'else' clause included to call reset() when available() returns false.  (See the example sketches in the library.)
+isConnected()<br>
+Returns 'true' if the sensor is still responding as expected, and able to provide valid data. It does not collect a data set from the sensor.
 
-getTiltLevelOffsetAngleX() -- Returns a double float of the tilt offset from level value in degrees for the X direction.
+available()<br>
+Reads the raw SCL3300 sensor data as a group so that all the data is consistent.  Call this first before using the functions below.  Starting with Version 3.0.0, this call should be the conditional in an 'if' statement, and an 'else' clause included to call reset() when available() returns false.  (See the example sketches in the library.)
 
-getTiltLevelOffsetAngleY() -- Returns a double float of the tilt offset from level value in degrees for the Y direction.
+getTiltLevelOffsetAngleX()<br>
+Returns a double float of the tilt offset from level value in degrees for the X direction.
 
-getTiltLevelOffsetAngleZ() -- Returns a double float of the tilt offset from level value in degrees for the Z direction.
+getTiltLevelOffsetAngleY()<br>
+Returns a double float of the tilt offset from level value in degrees for the Y direction.
 
-getCalculatedAngleX() -- Returns a double float of the tilt value in degrees (0-360) for the X direction.
+getTiltLevelOffsetAngleZ()<br>
+Returns a double float of the tilt offset from level value in degrees for the Z direction.
 
-getCalculatedAngleY() -- Returns a double float of the tilt value in degrees (0-360) for the Y direction.
+getCalculatedAngleX()<br>
+Returns a double float of the tilt value in degrees (0-360) for the X direction.
 
-getCalculatedAngleZ() -- Returns a double float of the tilt value in degrees (0-360) for the Z direction.
+getCalculatedAngleY()<br>
+Returns a double float of the tilt value in degrees (0-360) for the Y direction.
 
-getCalculatedAccelerometerX() -- Returns a double float of the accelerometer value in units of 'g' for the X direction.
+getCalculatedAngleZ()<br>
+Returns a double float of the tilt value in degrees (0-360) for the Z direction.
 
-getCalculatedAccelerometerY() -- Returns a double float of the accelerometer value in units of 'g' for the Y direction.
+getCalculatedAccelerometerX()<br>
+Returns a double float of the accelerometer value in units of 'g' for the X direction.
 
-getCalculatedAccelerometerZ() -- Returns a double float of the accelerometer value in units of 'g' for the Z direction.
+getCalculatedAccelerometerY()<br>
+Returns a double float of the accelerometer value in units of 'g' for the Y direction.
 
-getTemperatureCelsius()   -- Returns a double float of the temperature in Celsius.
+getCalculatedAccelerometerZ()<br>
+Returns a double float of the accelerometer value in units of 'g' for the Z direction.
 
-getTemperatureFarenheit() -- Returns a double float of the temperature in Farenheit.
+getTemperatureCelsius()<br>
+Returns a double float of the temperature in Celsius.
+
+getTemperatureFarenheit()<br>
+Returns a double float of the temperature in Farenheit.
 
 
 Utility Functions available:
 
-reset()           -- Does a software reset of the SCL3300 sensor.
+reset()<br>
+Does a software reset of the SCL3300 sensor.
 
-getSerialNumber() -- Returns a long integer of the device Serial Number set by the manufacturer.
+getSerialNumber()<br>
+Returns a long integer of the device Serial Number set by the manufacturer.
 
-powerDownMode()   -- Puts the sensor in a power down mode to reduce power usage.
+powerDownMode()<br>
+Puts the sensor in a power down mode to reduce power usage.
 
-WakeMeUp()        -- Revives sensor from being powered down, so that it can start to generate sensor data.
+WakeMeUp()<br>
+Revives sensor from being powered down, so that it can start to generate sensor data.
 
-setMode(modeNum) -- Sets the sensor mode to the number provided as modeNum.  The default mode is '4'.  Valid values are 1, 2, 3, and 4.
+setMode(modeNum)<br>
+Sets the sensor mode to the number provided as modeNum.  The default mode is '4'.  Valid values are 1, 2, 3, and 4.
 
-setFastReadMode() -- Using Fast Read Mode in the library works by keeping the SPI connection continuously open.  This may or may not affect the behavior of other hardware interactions, depending on the sketch design.  Fast Read Mode is considered an advanced use case, and not recommended for the beginner.
+setFastReadMode()<br>
+Using Fast Read Mode in the library works by keeping the SPI connection continuously open.  This may or may not affect the behavior of other hardware interactions, depending on the sketch design.  Fast Read Mode is considered an advanced use case, and not recommended for the beginner.
 
-stopFastReadMode() -- This stops the Fast Read Mode in the library by closing the SPI connection that was open, and doing a reset of the SCL3300.  This may or may not affect the behavior of other hardware interactions, depending on the sketch design.  Fast Read Mode is considered an advanced use case, and not recommended for the beginner.
+stopFastReadMode()<br>
+This stops the Fast Read Mode in the library by closing the SPI connection that was open, and doing a reset of the SCL3300.  This may or may not affect the behavior of other hardware interactions, depending on the sketch design.  Fast Read Mode is considered an advanced use case, and not recommended for the beginner.

--- a/examples/Example9_AlternateSPI/Example9_AlternateSPI.ino
+++ b/examples/Example9_AlternateSPI/Example9_AlternateSPI.ino
@@ -1,0 +1,70 @@
+/* Alternate SPI interface used to Read Tilt angles from Murata SCL3300 Inclinometer
+ * Version 3.3.0 - September 13, 2021
+ * Example9_AlternateSPI
+*/
+
+#include <SPI.h>
+#include <SCL3300.h>
+
+SCL3300 inclinometer;
+
+// Need the following define for SAMD processors
+#if defined(ARDUINO_SAMD_ZERO) && defined(SERIAL_PORT_USBVIRTUAL)
+  #define Serial SERIAL_PORT_USBVIRTUAL
+#endif
+
+void setup() {
+  Serial.begin(9600);
+  delay(2000); //SAMD boards may need a long time to init SerialUSB
+  Serial.println("Define a specific SPI interface for the SCL3300 Inclinometer");
+
+  // Change the begin() parameters here, as needed, to reference the SPI
+  // interface being used for the SCL3300 inclinometer.
+  // The default Arduino interface is "SPI", and is shown here
+  if (inclinometer.begin(SPI, 10) == false) {
+    Serial.println("Murata SCL3300 inclinometer not connected.");
+    while(1); //Freeze
+  } else
+    Serial.println("Murata SCL3300 inclinometer is connected.");
+}
+
+void loop() {
+  if (inclinometer.isConnected()) {
+    Serial.println("Inclinometer is still alive...");
+  } else {
+    Serial.println("Inclinometer error detected...");
+    delay(1000);
+  }
+  if (inclinometer.available()) { //Get next block of data from sensor
+    Serial.print("Raw X Tilt: ");
+    Serial.print(inclinometer.sclData.AngX);
+    Serial.print("\t");
+    Serial.print("Y Tilt: ");
+    Serial.print(inclinometer.sclData.AngY);
+    Serial.print("\t");
+    Serial.print("Z Tilt: ");
+    Serial.println(inclinometer.sclData.AngZ);
+    Serial.print("Raw X Accel: ");
+    Serial.print(inclinometer.sclData.AccX);
+    Serial.print("\t");
+    Serial.print("Y Accel: ");
+    Serial.print(inclinometer.sclData.AccY);
+    Serial.print("\t");
+    Serial.print("Z Accel: ");
+    Serial.println(inclinometer.sclData.AccZ);
+    Serial.print("SCL3300 STO register: ");
+    Serial.print((inclinometer.sclData.STO >> 8) & 0xff, HEX);
+    Serial.print("\t");
+    Serial.print("WHOAMI register: ");
+    Serial.println(inclinometer.sclData.WHOAMI, HEX);
+    Serial.print("Raw Temperature: ");
+    Serial.println(inclinometer.sclData.TEMP);
+    Serial.print("Serial Number Register: ");
+    Serial.print(inclinometer.getSerialNumber());
+    Serial.print("B33");
+    Serial.print("\t");
+    Serial.print("SL3300 Status Summary Register: ");
+    Serial.println(inclinometer.sclData.StatusSum, HEX);
+    delay(1000);
+  } else inclinometer.reset();
+}

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SCL3300
-version=3.2.0
+version=3.3.0
 author=David Armstrong <mamoru.tbreesama@gmail.com>
 maintainer=David Armstrong <mamoru.tbreesama@gmail.com>
 sentence=A library for SPI communication with the Murata SCL3300 Inclinometer sensor.

--- a/src/SCL3300.cpp
+++ b/src/SCL3300.cpp
@@ -2,14 +2,14 @@
 SCL3300.cpp
 SCL3300 Arduino Driver
 David Armstrong
-Version 3.2.0 - September 3, 2021
+Version 3.3.0 - September 13, 2021
 https://github.com/DavidArmstrong/SCL3300
 
 Resources:
 Uses SPI.h for SPI operation
 
 Development environment specifics:
-Arduino IDE 1.8.9, 1.8.11, 1.8.12, 1.8.13, 1.8.15
+Arduino IDE 1.8.15
 
 This code is released under the [MIT License](http://opensource.org/licenses/MIT).
 Please review the LICENSE.md file included with this example.
@@ -23,7 +23,7 @@ Distributed as-is; no warranty is given.
 // Public Methods //////////////////////////////////////////////////////////
 // Set the sensor mode to the number provided as modeNum.
 boolean SCL3300::setMode(int modeNum) {
-  //Set Sensor mode - If not called, the default is mode 4, as set in header file
+  // Set Sensor mode - If not called, the default is mode 4, as set in header file
   // Only allowed values are: 1,2,3,4
   if (modeNum > 0 && modeNum < 5) {
     scl3300_mode = modeNum;
@@ -40,9 +40,10 @@ boolean SCL3300::setMode(int modeNum) {
 
 // Current Version of begin() to initialize the library and the SCL3300
 boolean SCL3300::begin(void) {
-  if (_spiPort == nullptr) _spiPort = &SPI;
-
   //This is the updated Version 3 begin function
+  // Determine if we need to set up to use the default SPI interface, or some other one
+  if (_spiPort == nullptr) _spiPort = &SPI;
+  
   //Wait the required 1 ms before initializing the SCL3300 inclinomenter
   unsigned long startmillis = millis();
   while (millis() - startmillis < 1) ;
@@ -81,17 +82,16 @@ boolean SCL3300::begin(void) {
 }
 
 // Set up the SPI communication with the SCL3300 with provided Chip Select pin number, and provided SPI port
-// This is NOT supported at this time
 boolean SCL3300::begin(SPIClass &spiPort, uint8_t csPin) {
   scl3300_csPin = csPin;
   _spiPort = &spiPort; //Grab the port the user wants us to use
-
   return begin();
 } // begin
 
 // Set up the SPI communication with the SCL3300 with provided Chip Select pin number
 boolean SCL3300::begin(uint8_t csPin) {
   scl3300_csPin = csPin;
+  _spiPort = &SPI; // With this call, we do the default SPI interface
   return begin();
 } // begin
 

--- a/src/SCL3300.cpp
+++ b/src/SCL3300.cpp
@@ -40,6 +40,8 @@ boolean SCL3300::setMode(int modeNum) {
 
 // Current Version of begin() to initialize the library and the SCL3300
 boolean SCL3300::begin(void) {
+  if (_spiPort == nullptr) _spiPort = &SPI;
+
   //This is the updated Version 3 begin function
   //Wait the required 1 ms before initializing the SCL3300 inclinomenter
   unsigned long startmillis = millis();
@@ -82,9 +84,7 @@ boolean SCL3300::begin(void) {
 // This is NOT supported at this time
 boolean SCL3300::begin(SPIClass &spiPort, uint8_t csPin) {
   scl3300_csPin = csPin;
-
   _spiPort = &spiPort; //Grab the port the user wants us to use
-  _spiPort->begin(); //call begin, in case the user forgot
 
   return begin();
 } // begin
@@ -353,14 +353,14 @@ double SCL3300::acceleration(int16_t SCL3300_ACC) { //two's complement value exp
 //private functions for serial transmission
 // Begin SPI bus transmission to the device
 void SCL3300::beginTransmission() {
-  SPI.beginTransaction(spiSettings);
+  _spiPort->beginTransaction(spiSettings);
 } //beginTransmission
 
 // End SPI bus transmission to the device
 void SCL3300::endTransmission() {
   // take the chip/slave select high to de-select:
   digitalWrite(scl3300_csPin, HIGH);
-  SPI.endTransaction();
+  _spiPort->endTransaction();
   unsigned long startmillis = millis();
   while (millis() - startmillis < 1) ; //wait a bit
 } //endTransmission
@@ -368,7 +368,7 @@ void SCL3300::endTransmission() {
 //Initialize the Arduino SPI library for the SCL3300 hardware
 void SCL3300::initSPI() {
   //Initialize the Arduino SPI library for the SCL3300 hardware
-  SPI.begin();
+  _spiPort->begin();
   // Maximum SPI frequency is 2 MHz - 4 MHz to achieve the best performance
   // initialize the chip select pin:
   pinMode(scl3300_csPin, OUTPUT);
@@ -432,7 +432,7 @@ unsigned long SCL3300::transfer(unsigned long value) {
   digitalWrite(scl3300_csPin, LOW); //Now chip select can be enabled for the full 32 bit xfer
   SCL3300_DATA = 0;
   for (int i = 3; i >= 0; i--) { //Xfers are done MSB first
-    dataorig.bit8[i] = SPI.transfer(dataorig.bit8[i]);
+    dataorig.bit8[i] = _spiPort->transfer(dataorig.bit8[i]);
   }
   SCL3300_DATA = dataorig.bit8[1] + (dataorig.bit8[2] << 8);
   SCL3300_CRC = dataorig.bit8[0];


### PR DESCRIPTION
Looks like a begin() function was started for this support, but
the rest of the library was still hardcoded to use SPI.

For boards like the Teensy with multiple SPI hardware peripherals
this change allows the user to specify which to use.